### PR TITLE
feat: Auto-start FIFO/Socket zones when loading layouts

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -492,7 +492,7 @@ class Application:
         args = parts[1:]
 
         # Look up command handler
-        handler = self.state_machine.commands.get(cmd_name)
+        handler = self.state_machine._command_handlers.get(cmd_name)
         if handler:
             return handler(args)
 
@@ -1554,6 +1554,8 @@ class Application:
                 self.zone_manager,
                 self.zone_executor,
                 pty_handler=self.pty_handler,
+                fifo_handler=self.fifo_handler,
+                socket_handler=self.socket_handler,
                 clear_existing=clear_existing,
             )
 


### PR DESCRIPTION
## Summary
- Adds `path` and `port` fields to `LayoutZone` for FIFO/socket zone configuration
- Passes `fifo_handler` and `socket_handler` to `apply_layout()` method
- Automatically starts FIFO/Socket handlers when loading zones from layouts
- Fixes command handler lookup (uses `_command_handlers` instead of `commands`)

Fixes #34

## Test Plan
- [ ] Load `live-dashboard` layout with FIFO zone - verify FIFO listener starts
- [ ] Load layout with socket zone - verify socket server starts
- [ ] Test sending data to FIFO zone after layout load
- [ ] Test sending data to socket zone after layout load
- [ ] Verify no regression on PIPE/WATCH/PTY zone auto-start

## Testing Commands
```bash
# Start my-grid with server
python mygrid.py --server

# Load layout with FIFO zone
echo ':layout load live-dashboard' | nc localhost 8765

# Check FIFO is listening
ls -la /tmp/dashboard-events.fifo

# Send test data (should appear in zone)
timeout 2 bash -c 'echo "Test event" > /tmp/dashboard-events.fifo'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)