### PR TITLE
feat: Add hot-reload for layouts with proper cleanup

### DIFF
--- a/src/zones.py
+++ b/src/zones.py
@@ -244,6 +244,12 @@ class Zone:
             canvas.set(x + i, y + h - 1, horiz)
         canvas.set(x + w - 1, y + h - 1, br)
 
+    def clear_from_canvas(self, canvas) -> None:
+        """Clear this zone's region from the canvas."""
+        for row in range(self.height):
+            for col in range(self.width):
+                canvas.clear(self.x + col, self.y + row)
+
     def contains(self, cx: int, cy: int) -> bool:
         """Check if a canvas coordinate is within this zone."""
         return (self.x <= cx < self.x + self.width and
@@ -611,6 +617,12 @@ class ZoneManager:
 
     def clear(self) -> None:
         """Remove all zones."""
+        self._zones.clear()
+
+    def clear_with_canvas(self, canvas) -> None:
+        """Remove all zones and clear their canvas regions."""
+        for zone in self._zones.values():
+            zone.clear_from_canvas(canvas)
         self._zones.clear()
 
     def __len__(self) -> int:


### PR DESCRIPTION
## Summary
Add proper cleanup when reloading layouts, and a new `:layout reload` command.

Fixes #39

## Problem
Previously, `:layout load NAME --clear` would clear zones from the manager but leave handlers (FIFO, Socket, PTY, Watch) running in the background, causing resource leaks and potential conflicts.

## Solution
- Stop all handlers before clearing zones when using `--clear`
- Add `:layout reload NAME` as a convenient shortcut

## Changes
- Stop watch zone threads before clearing
- Stop PTY sessions before clearing
- Stop FIFO listeners before clearing
- Stop socket listeners before clearing
- Add `:layout reload NAME` command

## Usage
```bash
# Reload layout with clean slate
:layout reload live-dashboard

# Same effect
:layout load live-dashboard --clear
```

## Test Plan
- [ ] Load layout with FIFO zone
- [ ] Send messages to FIFO
- [ ] `:layout reload` with different layout
- [ ] Verify old FIFO is stopped (check `/tmp/*.fifo`)
- [ ] Verify new layout handlers start correctly
- [ ] No orphaned threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)