### PR TITLE
fix: Improve WSL clipboard integration

### DIFF
--- a/src/zones.py
+++ b/src/zones.py
@@ -1243,10 +1243,12 @@ class Clipboard:
             text = self.text
 
             # Try different clipboard commands
-            for cmd in [['xclip', '-selection', 'clipboard'],
+            # WSL: prefer clip.exe for Windows clipboard integration
+            for cmd in [['clip.exe'],  # WSL -> Windows
+                        ['xclip', '-selection', 'clipboard'],
                         ['xsel', '--clipboard', '--input'],
                         ['pbcopy'],  # macOS
-                        ['clip']]:  # Windows
+                        ['clip']]:  # Windows native
                 try:
                     proc = subprocess.run(
                         cmd,
@@ -1274,10 +1276,12 @@ class Clipboard:
             import subprocess
 
             # Try different clipboard commands
-            for cmd in [['xclip', '-selection', 'clipboard', '-o'],
+            # WSL: prefer powershell.exe for Windows clipboard integration
+            for cmd in [['powershell.exe', '-command', 'Get-Clipboard'],  # WSL -> Windows
+                        ['xclip', '-selection', 'clipboard', '-o'],
                         ['xsel', '--clipboard', '--output'],
                         ['pbpaste'],  # macOS
-                        ['powershell', '-command', 'Get-Clipboard']]:  # Windows
+                        ['powershell', '-command', 'Get-Clipboard']]:  # Windows native
                 try:
                     proc = subprocess.run(
                         cmd,


### PR DESCRIPTION
## Summary
Improve system clipboard integration for WSL environments.

Closes #28

## Changes
- Prefer `clip.exe` for copying in WSL (syncs with Windows clipboard)
- Prefer `powershell.exe` for pasting in WSL
- Existing `xclip`/`xsel` still work as fallback on native Linux

## Note
The system clipboard commands **already existed**:
- `:yank system` - Read from system clipboard into my-grid
- `:paste system` - Copy my-grid clipboard to system

This PR just improves WSL→Windows clipboard sync.

## Test Plan
- [ ] In WSL: `:yank 10 5` then `:paste system` - verify content in Windows clipboard
- [ ] Copy text in Windows, then `:yank system` in my-grid - verify content imported
- [ ] Native Linux still works with xclip fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)