### PR TITLE
Implement Visual Selection mode (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,28 @@ Renderer.render(canvas, viewport, status) → Terminal Display
 | COMMAND | `:` | typing | Execute commands |
 | MARK_SET | `m` | a-z, 0-9 | Set bookmark at cursor |
 | MARK_JUMP | `'` | a-z, 0-9 | Jump to bookmark |
+| VISUAL | `v` | wasd/arrows | Visual selection mode |
 
 Exit any mode with `Esc`.
+
+---
+
+## Visual Selection
+
+Visual selection mode allows selecting a rectangular region on the canvas for bulk operations.
+
+**Enter**: Press `v` in NAV mode
+**Exit**: Press `Esc`
+
+| Key | Action |
+|-----|--------|
+| `wasd` / arrows | Extend/shrink selection |
+| `y` | Yank (copy) selection to clipboard |
+| `d` | Delete selection (clear cells) |
+| `f` | Fill selection with character (opens command) |
+| `Esc` | Cancel selection |
+
+The selection is highlighted in cyan. The cursor shows one corner, the anchor is at the starting position.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add vim-style visual selection mode for rectangular region operations
- New `VISUAL` mode entered with `v` key from NAV mode
- Selection class tracks anchor point and cursor for rectangle
- Movement keys extend/shrink selection
- Operations: `y` (yank), `d` (delete), `f` (fill selection)
- Selection highlighted in cyan
- New `:fill` command for rectangular fill operations

## Test plan
- [ ] Press `v` in NAV mode to enter VISUAL mode
- [ ] Move with wasd/arrows to extend selection
- [ ] Press `y` to yank selection to clipboard
- [ ] Press `d` to delete/clear selected cells
- [ ] Press `f` to fill selection with character
- [ ] Press `Esc` to cancel selection
- [ ] Verify selection is highlighted in cyan

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)