### PR TITLE
docs: Add API scripting guide and example scripts (Issue #51)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,16 +79,16 @@ Renderer.render(canvas, viewport, status) → Terminal Display
 
 ## Modes
 
-| Mode | Entry | Keys | Behavior |
-|------|-------|------|----------|
-| NAV | default | wasd/arrows | Move cursor |
-| PAN | `p` | wasd/arrows | Pan viewport, cursor follows |
-| EDIT | `i` | typing | Draw characters on canvas |
-| COMMAND | `:` | typing | Execute commands |
-| MARK_SET | `m` | a-z, 0-9 | Set bookmark at cursor |
-| MARK_JUMP | `'` | a-z, 0-9 | Jump to bookmark |
-| VISUAL | `v` | wasd/arrows | Visual selection mode |
-| DRAW | `D` | wasd/arrows | Line drawing mode |
+| Mode      | Entry   | Keys        | Behavior                     |
+| --------- | ------- | ----------- | ---------------------------- |
+| NAV       | default | wasd/arrows | Move cursor                  |
+| PAN       | `p`     | wasd/arrows | Pan viewport, cursor follows |
+| EDIT      | `i`     | typing      | Draw characters on canvas    |
+| COMMAND   | `:`     | typing      | Execute commands             |
+| MARK_SET  | `m`     | a-z, 0-9    | Set bookmark at cursor       |
+| MARK_JUMP | `'`     | a-z, 0-9    | Jump to bookmark             |
+| VISUAL    | `v`     | wasd/arrows | Visual selection mode        |
+| DRAW      | `D`     | wasd/arrows | Line drawing mode            |
 
 Exit any mode with `Esc`.
 
@@ -101,13 +101,13 @@ Visual selection mode allows selecting a rectangular region on the canvas for bu
 **Enter**: Press `v` in NAV mode
 **Exit**: Press `Esc`
 
-| Key | Action |
-|-----|--------|
-| `wasd` / arrows | Extend/shrink selection |
-| `y` | Yank (copy) selection to clipboard |
-| `d` | Delete selection (clear cells) |
-| `f` | Fill selection with character (opens command) |
-| `Esc` | Cancel selection |
+| Key             | Action                                        |
+| --------------- | --------------------------------------------- |
+| `wasd` / arrows | Extend/shrink selection                       |
+| `y`             | Yank (copy) selection to clipboard            |
+| `d`             | Delete selection (clear cells)                |
+| `f`             | Fill selection with character (opens command) |
+| `Esc`           | Cancel selection                              |
 
 The selection is highlighted in cyan. The cursor shows one corner, the anchor is at the starting position.
 
@@ -120,28 +120,32 @@ Draw mode allows tracing lines with box-drawing characters using cursor movement
 **Enter**: Press `D` in NAV mode or use `:draw` command
 **Exit**: Press `Esc`
 
-| Key | Action |
-|-----|--------|
+| Key             | Action                                             |
+| --------------- | -------------------------------------------------- |
 | `wasd` / arrows | Draw line in direction (pen down) or move (pen up) |
-| `Space` | Toggle pen up/down |
-| `Esc` | Exit draw mode |
+| `Space`         | Toggle pen up/down                                 |
+| `Esc`           | Exit draw mode                                     |
 
 **Pen States**:
+
 - **Pen DOWN**: Movement draws lines
 - **Pen UP**: Movement just moves cursor without drawing
 
 **Joystick Support**:
+
 - D-pad/stick: Move and draw
 - Button A: Toggle pen up/down
 - Button B: Exit draw mode
 
 **Features**:
+
 - Uses current border style (`:border ascii/unicode/rounded/double/heavy`)
 - Auto-detects corners when changing direction
 - Smart junctions when lines cross (┼) or meet (├ ┤ ┬ ┴)
 - Uses current drawing colors (`:color`)
 
 **Example**:
+
 ```
 :border unicode    # Set line style
 D                  # Enter draw mode (pen down)
@@ -183,37 +187,37 @@ Zones are named rectangular regions that can contain dynamic content. Inspired b
 
 ### Zone Types
 
-| Type | Description | Command |
-|------|-------------|---------|
-| STATIC | Plain text region (default) | `:zone create NAME X Y W H` |
-| PIPE | One-shot command output | `:zone pipe NAME W H CMD` |
-| WATCH | Periodic refresh command | `:zone watch NAME W H INTERVAL CMD` |
-| PTY | Live terminal session (Unix) | `:zone pty NAME W H [SHELL]` |
-| PAGER | Paginated file viewer with colors | `:zone pager NAME W H FILE` |
-| FIFO | Named pipe listener (Unix) | `:zone fifo NAME W H PATH` |
-| SOCKET | TCP port listener | `:zone socket NAME W H PORT` |
-| CLIPBOARD | Yank/paste buffer | `:clipboard zone` |
+| Type      | Description                       | Command                             |
+| --------- | --------------------------------- | ----------------------------------- |
+| STATIC    | Plain text region (default)       | `:zone create NAME X Y W H`         |
+| PIPE      | One-shot command output           | `:zone pipe NAME W H CMD`           |
+| WATCH     | Periodic refresh command          | `:zone watch NAME W H INTERVAL CMD` |
+| PTY       | Live terminal session (Unix)      | `:zone pty NAME W H [SHELL]`        |
+| PAGER     | Paginated file viewer with colors | `:zone pager NAME W H FILE`         |
+| FIFO      | Named pipe listener (Unix)        | `:zone fifo NAME W H PATH`          |
+| SOCKET    | TCP port listener                 | `:zone socket NAME W H PORT`        |
+| CLIPBOARD | Yank/paste buffer                 | `:clipboard zone`                   |
 
 ### Zone Commands
 
-| Command | Description |
-|---------|-------------|
-| `:zone create NAME X Y W H` | Create static zone at coordinates |
-| `:zone create NAME here W H` | Create zone at cursor position |
-| `:zone pipe NAME W H CMD` | Create pipe zone, execute command once |
-| `:zone watch NAME W H 5s CMD` | Create watch zone, refresh every 5 seconds |
-| `:zone pty NAME W H [SHELL]` | Create PTY zone with live terminal (Unix) |
-| `:zone fifo NAME W H PATH` | Create FIFO zone listening on named pipe (Unix) |
-| `:zone socket NAME W H PORT` | Create socket zone listening on TCP port |
-| `:zone delete NAME` | Delete zone |
-| `:zone goto NAME` | Jump cursor to zone center |
-| `:zone info [NAME]` | Show zone info |
-| `:zone refresh NAME` | Manually refresh pipe/watch zone |
-| `:zone pause NAME` | Pause watch zone refresh |
-| `:zone resume NAME` | Resume watch zone refresh |
-| `:zone send NAME TEXT` | Send text to PTY zone |
-| `:zone focus NAME` | Focus PTY zone for keyboard input |
-| `:zones` | List all zones |
+| Command                       | Description                                     |
+| ----------------------------- | ----------------------------------------------- |
+| `:zone create NAME X Y W H`   | Create static zone at coordinates               |
+| `:zone create NAME here W H`  | Create zone at cursor position                  |
+| `:zone pipe NAME W H CMD`     | Create pipe zone, execute command once          |
+| `:zone watch NAME W H 5s CMD` | Create watch zone, refresh every 5 seconds      |
+| `:zone pty NAME W H [SHELL]`  | Create PTY zone with live terminal (Unix)       |
+| `:zone fifo NAME W H PATH`    | Create FIFO zone listening on named pipe (Unix) |
+| `:zone socket NAME W H PORT`  | Create socket zone listening on TCP port        |
+| `:zone delete NAME`           | Delete zone                                     |
+| `:zone goto NAME`             | Jump cursor to zone center                      |
+| `:zone info [NAME]`           | Show zone info                                  |
+| `:zone refresh NAME`          | Manually refresh pipe/watch zone                |
+| `:zone pause NAME`            | Pause watch zone refresh                        |
+| `:zone resume NAME`           | Resume watch zone refresh                       |
+| `:zone send NAME TEXT`        | Send text to PTY zone                           |
+| `:zone focus NAME`            | Focus PTY zone for keyboard input               |
+| `:zones`                      | List all zones                                  |
 
 ### Examples
 
@@ -255,6 +259,7 @@ Zones display with borders showing type indicator: `[P]` for pipe, `[W]` for wat
 PTY zones provide live interactive terminals with full echo, ANSI color support, and scrollback:
 
 **Basic Usage:**
+
 1. Create PTY zone: `:zone pty TERM 80 24`
 2. Navigate cursor into the zone
 3. Press **Enter** to focus (or use `:zone focus TERM`)
@@ -263,6 +268,7 @@ PTY zones provide live interactive terminals with full echo, ANSI color support,
 6. Press **Escape** to unfocus and return to canvas navigation
 
 **Terminal Emulation:**
+
 - Full VT100/ANSI terminal emulation via `pyte`
 - ANSI color support (foreground/background, 256-color palette mapped to 8 colors)
 - Cursor control, backspace, escape sequences all work
@@ -272,30 +278,34 @@ PTY zones provide live interactive terminals with full echo, ANSI color support,
 
 When focused on a PTY zone, you can scroll through terminal history:
 
-| Key | Action |
-|-----|--------|
+| Key    | Action                                   |
+| ------ | ---------------------------------------- |
 | `PgUp` | Scroll up half page (enters scroll mode) |
-| `PgDn` | Scroll down half page |
-| `Home` | Go to top of history |
-| `End` | Go to bottom (re-enables auto-scroll) |
-| `Esc` | Unfocus PTY |
+| `PgDn` | Scroll down half page                    |
+| `Home` | Go to top of history                     |
+| `End`  | Go to bottom (re-enables auto-scroll)    |
+| `Esc`  | Unfocus PTY                              |
 
 **Scroll Modes:**
+
 - **Auto-scroll** (default): Always shows latest output, scrolls automatically
 - **Manual scroll**: PgUp enters this mode, shows scroll position in status line
 - Press `End` to return to auto-scroll
 
 **Status Line:**
+
 - Auto-scroll mode: `[PTY] TERM - PgUp:scroll Esc:unfocus`
 - Scroll mode: `[PTY SCROLL] TERM - 50/200 - End:auto Esc:unfocus`
 
 **Color Support:**
+
 - ANSI colors display correctly (foreground and background)
 - 256-color palette supported (mapped to basic 8 colors)
 - Colors preserved on current screen
 - Note: Scrollback history (from `pyte` limitations) shows plain text without colors
 
 **Use Cases:**
+
 - Review command output that scrolled past
 - Copy error messages from history
 - Navigate through log files
@@ -312,27 +322,27 @@ Set drawing colors for text and regions. Colors persist until changed.
 
 ### Color Commands
 
-| Command | Description |
-|---------|-------------|
-| `:color FG [BG]` | Set drawing color (foreground, optional background) |
-| `:color off` | Reset to default (terminal) colors |
-| `:color apply W H` | Apply current color to region at cursor |
-| `:palette` | Show available color names |
-| `:color` | Show current color setting |
+| Command            | Description                                         |
+| ------------------ | --------------------------------------------------- |
+| `:color FG [BG]`   | Set drawing color (foreground, optional background) |
+| `:color off`       | Reset to default (terminal) colors                  |
+| `:color apply W H` | Apply current color to region at cursor             |
+| `:palette`         | Show available color names                          |
+| `:color`           | Show current color setting                          |
 
 ### Available Colors
 
-| Name | Value | Description |
-|------|-------|-------------|
-| `black` | 0 | Black |
-| `red` | 1 | Red |
-| `green` | 2 | Green |
-| `yellow` | 3 | Yellow |
-| `blue` | 4 | Blue |
-| `magenta` | 5 | Magenta |
-| `cyan` | 6 | Cyan |
-| `white` | 7 | White |
-| `default` | -1 | Terminal default |
+| Name      | Value | Description      |
+| --------- | ----- | ---------------- |
+| `black`   | 0     | Black            |
+| `red`     | 1     | Red              |
+| `green`   | 2     | Green            |
+| `yellow`  | 3     | Yellow           |
+| `blue`    | 4     | Blue             |
+| `magenta` | 5     | Magenta          |
+| `cyan`    | 6     | Cyan             |
+| `white`   | 7     | White            |
+| `default` | -1    | Terminal default |
 
 ### Examples
 
@@ -364,14 +374,14 @@ Layouts save and restore zone configurations. Stored in `~/.config/mygrid/layout
 
 ### Layout Commands
 
-| Command | Description |
-|---------|-------------|
-| `:layout list` | List available layouts |
-| `:layout load NAME` | Load a layout (creates zones) |
+| Command                     | Description                                |
+| --------------------------- | ------------------------------------------ |
+| `:layout list`              | List available layouts                     |
+| `:layout load NAME`         | Load a layout (creates zones)              |
 | `:layout load NAME --clear` | Load layout, clearing existing zones first |
-| `:layout save NAME [DESC]` | Save current zones as layout |
-| `:layout delete NAME` | Delete a layout |
-| `:layout info NAME` | Show layout details |
+| `:layout save NAME [DESC]`  | Save current zones as layout               |
+| `:layout delete NAME`       | Delete a layout                            |
+| `:layout info NAME`         | Show layout details                        |
 
 ### Default Layouts
 
@@ -413,62 +423,62 @@ zones:
 
 ## Commands
 
-| Command | Aliases | Description |
-|---------|---------|-------------|
-| `quit` | `q` | Exit editor |
-| `write` | `w` | Save project |
-| `wq` | - | Save and quit |
-| `goto X Y` | `g` | Move cursor to coordinates |
-| `origin [X Y\|here]` | - | Set canvas origin |
-| `clear` | - | Clear entire canvas |
-| `rect W H [char]` | - | Draw rectangle at cursor |
-| `line X2 Y2 [char]` | - | Draw line from cursor |
-| `text MESSAGE` | - | Write text at cursor |
-| `grid major\|minor\|N` | - | Toggle/configure grid |
-| `ydir up\|down` | - | Set Y-axis direction |
-| `export [file]` | - | Export as plain text |
-| `import file` | - | Import text file |
-| `marks` | - | List all bookmarks |
-| `mark KEY [X Y]` | - | Set bookmark |
-| `delmark KEY` | - | Delete bookmark |
-| `delmarks` | - | Delete all bookmarks |
-| `zone SUBCMD` | - | Zone management (see Zones section) |
-| `zones` | - | List all zones |
-| `layout SUBCMD` | - | Layout management (see Layouts section) |
-| `yank W H` | `y` | Yank region at cursor to clipboard |
-| `yank zone NAME` | - | Yank zone content to clipboard |
-| `yank system` | - | Read from system clipboard |
-| `paste` | `p` | Paste clipboard at cursor |
-| `paste system` | - | Copy clipboard to system clipboard |
-| `clipboard` | - | Show clipboard info |
-| `clipboard clear` | - | Clear clipboard |
-| `clipboard zone` | - | Create clipboard zone |
-| `box [STYLE] TEXT` | - | Draw ASCII box (requires `boxes`) |
-| `figlet [-f FONT] TEXT` | - | Draw ASCII art text (requires `figlet`) |
-| `pipe COMMAND` | - | Execute command, write output at cursor |
-| `tools` | - | Show external tool status |
+| Command                 | Aliases | Description                             |
+| ----------------------- | ------- | --------------------------------------- |
+| `quit`                  | `q`     | Exit editor                             |
+| `write`                 | `w`     | Save project                            |
+| `wq`                    | -       | Save and quit                           |
+| `goto X Y`              | `g`     | Move cursor to coordinates              |
+| `origin [X Y\|here]`    | -       | Set canvas origin                       |
+| `clear`                 | -       | Clear entire canvas                     |
+| `rect W H [char]`       | -       | Draw rectangle at cursor                |
+| `line X2 Y2 [char]`     | -       | Draw line from cursor                   |
+| `text MESSAGE`          | -       | Write text at cursor                    |
+| `grid major\|minor\|N`  | -       | Toggle/configure grid                   |
+| `ydir up\|down`         | -       | Set Y-axis direction                    |
+| `export [file]`         | -       | Export as plain text                    |
+| `import file`           | -       | Import text file                        |
+| `marks`                 | -       | List all bookmarks                      |
+| `mark KEY [X Y]`        | -       | Set bookmark                            |
+| `delmark KEY`           | -       | Delete bookmark                         |
+| `delmarks`              | -       | Delete all bookmarks                    |
+| `zone SUBCMD`           | -       | Zone management (see Zones section)     |
+| `zones`                 | -       | List all zones                          |
+| `layout SUBCMD`         | -       | Layout management (see Layouts section) |
+| `yank W H`              | `y`     | Yank region at cursor to clipboard      |
+| `yank zone NAME`        | -       | Yank zone content to clipboard          |
+| `yank system`           | -       | Read from system clipboard              |
+| `paste`                 | `p`     | Paste clipboard at cursor               |
+| `paste system`          | -       | Copy clipboard to system clipboard      |
+| `clipboard`             | -       | Show clipboard info                     |
+| `clipboard clear`       | -       | Clear clipboard                         |
+| `clipboard zone`        | -       | Create clipboard zone                   |
+| `box [STYLE] TEXT`      | -       | Draw ASCII box (requires `boxes`)       |
+| `figlet [-f FONT] TEXT` | -       | Draw ASCII art text (requires `figlet`) |
+| `pipe COMMAND`          | -       | Execute command, write output at cursor |
+| `tools`                 | -       | Show external tool status               |
 
 ---
 
 ## Key Bindings
 
-| Key | Action |
-|-----|--------|
-| `wasd` / arrows | Move cursor |
-| `WASD` | Fast move (10x) |
-| `i` | Enter edit mode |
-| `p` | Toggle pan mode |
-| `:` or `/` | Enter command mode |
-| `m` + key | Set bookmark (a-z, 0-9) |
-| `'` + key | Jump to bookmark |
-| `Esc` | Exit current mode |
-| `g` / `G` | Toggle major/minor grid |
-| `0` | Toggle origin marker |
-| `Ctrl+S` | Save |
-| `Ctrl+O` | Open |
-| `Ctrl+N` | New |
-| `q` | Quit |
-| `F1` | Help |
+| Key             | Action                  |
+| --------------- | ----------------------- |
+| `wasd` / arrows | Move cursor             |
+| `WASD`          | Fast move (10x)         |
+| `i`             | Enter edit mode         |
+| `p`             | Toggle pan mode         |
+| `:` or `/`      | Enter command mode      |
+| `m` + key       | Set bookmark (a-z, 0-9) |
+| `'` + key       | Jump to bookmark        |
+| `Esc`           | Exit current mode       |
+| `g` / `G`       | Toggle major/minor grid |
+| `0`             | Toggle origin marker    |
+| `Ctrl+S`        | Save                    |
+| `Ctrl+O`        | Open                    |
+| `Ctrl+N`        | New                     |
+| `q`             | Quit                    |
+| `F1`            | Help                    |
 
 ---
 
@@ -593,6 +603,40 @@ $writer.WriteLine(":text Hello from Windows")
 $writer.Flush()
 ```
 
+### Python Client Library
+
+Use the included Python client for scripting:
+
+```python
+from scripts.mygrid_client import MyGridClient
+
+client = MyGridClient()
+client.goto(0, 0)
+client.text('Hello from Python!')
+client.rect(20, 10)
+client.zone_watch('STATUS', 60, 15, '10s', 'uptime')
+client.save('dashboard.json')
+```
+
+### Bash Helpers
+
+```bash
+# Send single command
+./scripts/mygrid-send ':text Hello'
+
+# Pipe command output to canvas
+ls -la | ./scripts/mygrid-pipe 0 0
+
+# Execute batch commands
+./scripts/batch_commands.py commands.txt
+```
+
+### Additional Resources
+
+- **[API Scripting Guide](docs/guides/api-scripting.md)** - Full documentation with patterns
+- **[scripts/](scripts/)** - Ready-to-use Python and Bash scripts
+- **[examples/music-organization/](examples/music-organization/)** - Real-world automation example
+
 ---
 
 ## Claude Code Integration
@@ -685,6 +729,7 @@ Load with: `:layout load claude-code`
 Run Claude Code directly inside a my-grid PTY zone for the ultimate meta-development experience:
 
 **Setup:**
+
 ```bash
 # Start my-grid with server mode
 python3 mygrid.py --server --layout pty-test
@@ -697,6 +742,7 @@ claude
 ```
 
 **What You Get:**
+
 - Claude Code's full TUI running inside my-grid
 - Full color support for Claude's interface
 - Scrollback through Claude's responses (PgUp/PgDn)
@@ -704,12 +750,14 @@ claude
 - README/docs visible alongside Claude
 
 **Use Cases:**
+
 - Ask Claude to help develop my-grid itself (meta!)
 - View documentation while chatting with Claude
 - Multiple Claude contexts in different zones
 - Compare responses from different Claude sessions side-by-side
 
 **Tips:**
+
 - Use `Esc` to unfocus PTY and navigate my-grid
 - Press `'c` to quickly jump back to Claude zone
 - Scrollback works - review Claude's previous responses with `PgUp`
@@ -717,6 +765,7 @@ claude
 - Run bash commands in a separate PTY zone while Claude is running
 
 **Meta-Development Workflow:**
+
 ```
 ┌──────────────┬──────────────┐
 │   README     │  BASH shell  │

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **A spatial canvas editor for your terminal.** Think vim meets infinite whiteboard, with live terminal zones and system monitoring built in.
 
-> *"Navigate to information, don't open windows."* – Inspired by Jef Raskin's *The Humane Interface*
+> _"Navigate to information, don't open windows."_ – Inspired by Jef Raskin's _The Humane Interface_
 
 ---
 
@@ -21,6 +21,7 @@ Traditional terminals are linear. my-grid gives you **infinite 2D space** where 
 - 🚀 **Navigate like vim** with bookmarks and modal editing
 
 **Perfect for:**
+
 - DevOps dashboards (disk usage, logs, git status in one spatial view)
 - System administration (live terminals + monitoring + notes)
 - ASCII art and diagramming
@@ -32,12 +33,14 @@ Traditional terminals are linear. my-grid gives you **infinite 2D space** where 
 ## 🎬 Demo
 
 <!-- TODO: Add terminal recording GIF here -->
+
 ```
 # Demo recording coming soon!
 # Run: asciinema rec demo/basic-usage.cast
 ```
 
 **Try it yourself:**
+
 ```bash
 pip install -r requirements.txt
 python mygrid.py
@@ -91,26 +94,29 @@ Hello World!
 ## 🎯 Core Features
 
 ### Infinite Canvas
+
 - **Sparse storage** – Only stores non-empty cells, unlimited space
 - **Configurable origin** – Y-up (mathematical) or Y-down (screen) coordinates
 - **Grid overlay** – Major/minor grid lines for alignment
 
 ### Vim-Style Navigation
+
 - **Modal editing** – NAV, EDIT, PAN, COMMAND, VISUAL, DRAW modes
 - **Bookmarks** – Quick jump with `m`/`'` + 36 slots (a-z, 0-9)
 - **Fast movement** – `WASD` for 10x speed
 
 ### Dynamic Zones (The Killer Feature)
 
-| Zone Type | Description | Use Case |
-|-----------|-------------|----------|
-| **PIPE** | One-shot command output | `tree`, `ls`, snapshot data |
-| **WATCH** | Auto-refreshing commands | `git status`, `df -h`, monitoring |
-| **PTY** | Live interactive terminal | Full shell, Python REPL, vim |
-| **FIFO** | Named pipe listener (Unix) | External process communication |
-| **SOCKET** | TCP port listener | Remote control, API integration |
+| Zone Type  | Description                | Use Case                          |
+| ---------- | -------------------------- | --------------------------------- |
+| **PIPE**   | One-shot command output    | `tree`, `ls`, snapshot data       |
+| **WATCH**  | Auto-refreshing commands   | `git status`, `df -h`, monitoring |
+| **PTY**    | Live interactive terminal  | Full shell, Python REPL, vim      |
+| **FIFO**   | Named pipe listener (Unix) | External process communication    |
+| **SOCKET** | TCP port listener          | Remote control, API integration   |
 
 **Example: DevOps Dashboard**
+
 ```bash
 :zone watch DISK 40 10 30s df -h
 :zone watch GIT 50 15 5s git status --short
@@ -119,11 +125,13 @@ Hello World!
 ```
 
 ### Layouts (Workspace Templates)
+
 - **Save/load** zone configurations
 - **Pre-built layouts:** `devops`, `development`, `monitoring`
 - **YAML format** – Easy to share and version control
 
 ### Visual Selection & Drawing
+
 - **Visual mode** – Select rectangular regions, yank/delete/fill
 - **Draw mode** – Trace lines with box-drawing characters
 - **Box tools** – Integrate `boxes`, `figlet` for ASCII art
@@ -134,43 +142,44 @@ Hello World!
 
 ### Navigation Mode (default)
 
-| Key | Action |
-|-----|--------|
-| `wasd` / arrows | Move cursor |
-| `WASD` | Fast move (10x) |
-| `i` | Enter edit mode |
-| `p` | Toggle pan mode |
-| `v` | Visual selection mode |
-| `D` | Draw mode |
-| `:` or `/` | Command mode |
-| `m` + key | Set bookmark (a-z, 0-9) |
-| `'` + key | Jump to bookmark |
-| `g` / `G` | Toggle grid |
-| `0` | Toggle origin marker |
-| `Esc` | Exit current mode |
+| Key             | Action                  |
+| --------------- | ----------------------- |
+| `wasd` / arrows | Move cursor             |
+| `WASD`          | Fast move (10x)         |
+| `i`             | Enter edit mode         |
+| `p`             | Toggle pan mode         |
+| `v`             | Visual selection mode   |
+| `D`             | Draw mode               |
+| `:` or `/`      | Command mode            |
+| `m` + key       | Set bookmark (a-z, 0-9) |
+| `'` + key       | Jump to bookmark        |
+| `g` / `G`       | Toggle grid             |
+| `0`             | Toggle origin marker    |
+| `Esc`           | Exit current mode       |
 
 ### Edit Mode
 
-| Key | Action |
-|-----|--------|
-| Type | Insert characters |
+| Key   | Action             |
+| ----- | ------------------ |
+| Type  | Insert characters  |
 | `Esc` | Return to NAV mode |
 
 ### Visual Mode
 
-| Key | Action |
-|-----|--------|
-| `wasd` / arrows | Extend selection |
-| `y` | Yank (copy) |
-| `d` | Delete selection |
-| `f` | Fill with character |
-| `Esc` | Cancel |
+| Key             | Action              |
+| --------------- | ------------------- |
+| `wasd` / arrows | Extend selection    |
+| `y`             | Yank (copy)         |
+| `d`             | Delete selection    |
+| `f`             | Fill with character |
+| `Esc`           | Cancel              |
 
 ---
 
 ## 📝 Essential Commands
 
 ### File Operations
+
 ```bash
 :w [file]          # Save project (default: mygrid.json)
 :q                 # Quit
@@ -180,6 +189,7 @@ Hello World!
 ```
 
 ### Drawing
+
 ```bash
 :rect W H [char]   # Draw rectangle at cursor
 :line X2 Y2 [char] # Draw line from cursor to point
@@ -189,6 +199,7 @@ Hello World!
 ```
 
 ### Zones
+
 ```bash
 :zone create NAME X Y W H              # Static zone
 :zone pipe NAME W H COMMAND            # One-shot command
@@ -201,6 +212,7 @@ Hello World!
 ```
 
 ### Layouts
+
 ```bash
 :layout list           # Show available layouts
 :layout load NAME      # Load layout
@@ -208,6 +220,7 @@ Hello World!
 ```
 
 ### Clipboard
+
 ```bash
 :yank W H              # Copy region to clipboard
 :paste                 # Paste clipboard
@@ -220,6 +233,7 @@ Hello World!
 ## 🔧 Use Cases
 
 ### 1. DevOps Monitoring Dashboard
+
 ```bash
 :layout load devops
 # Creates zones for: system logs, disk usage, processes, git status
@@ -227,6 +241,7 @@ Hello World!
 ```
 
 ### 2. Development Workspace
+
 ```bash
 :zone watch GIT 60 12 5s git status
 :zone pty VIM 80 30 vim
@@ -235,6 +250,7 @@ Hello World!
 ```
 
 ### 3. ASCII Diagramming
+
 ```bash
 :border unicode
 D  # Enter draw mode
@@ -243,6 +259,7 @@ D  # Enter draw mode
 ```
 
 ### 4. System Administration
+
 ```bash
 :zone watch LOGS 100 20 2s tail -f /var/log/syslog
 :zone watch DISK 40 10 30s df -h
@@ -253,15 +270,15 @@ D  # Enter draw mode
 
 ## 🆚 Comparison
 
-| Feature | my-grid | vim/emacs | tmux | Traditional Editor |
-|---------|---------|-----------|------|-------------------|
-| **Infinite 2D canvas** | ✅ | ❌ | ❌ | ❌ |
-| **Embedded live terminals** | ✅ (PTY zones) | ❌ | ✅ | ❌ |
-| **Spatial bookmarks** | ✅ | Limited | ❌ | ❌ |
-| **Auto-refreshing commands** | ✅ (Watch zones) | ❌ | ❌ | ❌ |
-| **Modal editing** | ✅ (Vim-style) | ✅ | ❌ | ❌ |
-| **ASCII drawing tools** | ✅ | Limited | ❌ | Limited |
-| **Workspace layouts** | ✅ (Save/load) | Limited | ✅ | ❌ |
+| Feature                      | my-grid          | vim/emacs | tmux | Traditional Editor |
+| ---------------------------- | ---------------- | --------- | ---- | ------------------ |
+| **Infinite 2D canvas**       | ✅               | ❌        | ❌   | ❌                 |
+| **Embedded live terminals**  | ✅ (PTY zones)   | ❌        | ✅   | ❌                 |
+| **Spatial bookmarks**        | ✅               | Limited   | ❌   | ❌                 |
+| **Auto-refreshing commands** | ✅ (Watch zones) | ❌        | ❌   | ❌                 |
+| **Modal editing**            | ✅ (Vim-style)   | ✅        | ❌   | ❌                 |
+| **ASCII drawing tools**      | ✅               | Limited   | ❌   | Limited            |
+| **Workspace layouts**        | ✅ (Save/load)   | Limited   | ✅   | ❌                 |
 
 **my-grid = tmux + vim + infinite whiteboard + system monitoring**
 
@@ -278,6 +295,7 @@ User Input → Renderer → InputEvent → ModeStateMachine → Application
 ```
 
 **Key components:**
+
 - `canvas.py` – Sparse dict storage, drawing primitives
 - `viewport.py` – Coordinate transforms, cursor management
 - `renderer.py` – Curses rendering, colors, grid overlay
@@ -306,6 +324,29 @@ ls -la | python mygrid-ctl box 0 0 80 25
 ```
 
 **Cross-platform:** Works from Windows → WSL via TCP sockets.
+
+### Scripting & Automation
+
+Automate my-grid with Python, Bash, or any language:
+
+```python
+from scripts.mygrid_client import MyGridClient
+
+client = MyGridClient()
+client.goto(0, 0)
+client.text('Automated dashboard')
+client.zone_watch('STATUS', 60, 15, '10s', 'uptime')
+```
+
+```bash
+# Pipe any command output to canvas
+ls -la | ./scripts/mygrid-pipe 0 0
+
+# Batch commands from file
+./scripts/batch_commands.py setup.txt
+```
+
+See **[API Scripting Guide](docs/guides/api-scripting.md)** for full documentation.
 
 ### PTY Zones with Scrollback (NEW!)
 
@@ -336,6 +377,7 @@ See [CLAUDE.md](CLAUDE.md) for full integration patterns.
 ## 📚 Documentation
 
 - **[Documentation Hub](docs/README.md)** – Guides, tutorials, and examples
+- **[API Scripting Guide](docs/guides/api-scripting.md)** – External automation with Python/Bash
 - **[CLAUDE.md](CLAUDE.md)** – Complete command reference, architecture, API docs
 - **[Getting Started](docs/guides/getting-started.md)** – First steps with my-grid
 - **[Zones Reference](docs/guides/zones-reference.md)** – Complete guide to zone types
@@ -368,6 +410,7 @@ python -m pytest tests/test_canvas.py -v
 ```
 
 **Ideas for contribution:**
+
 - 🎨 New border styles or color schemes
 - 🔌 Integration with external tools
 - 📦 Pre-built layouts for specific workflows
@@ -395,7 +438,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 
-- Inspired by **Jef Raskin's** *The Humane Interface* (spatial navigation philosophy)
+- Inspired by **Jef Raskin's** _The Humane Interface_ (spatial navigation philosophy)
 - Built with **curses** (terminal rendering)
 - Vim-style modal editing concepts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Welcome to the my-grid documentation! This directory contains guides, tutorials,
 
 - **[Coordinates Guide](guides/coordinates-guide.md)** - Understanding the canvas coordinate system
 - **[Zones Reference](guides/zones-reference.md)** - Complete guide to zone types and commands
+- **[API Scripting Guide](guides/api-scripting.md)** - External automation with Python, Bash, and more
 - **[CLAUDE.md](../CLAUDE.md)** - Full command reference and architecture documentation
 
 ### Tutorials
@@ -53,6 +54,7 @@ Welcome to the my-grid documentation! This directory contains guides, tutorials,
 - **Monitoring dashboard** → [Dashboard Quickstart](guides/dashboard-quickstart.md)
 - **ASCII art** → [Figlet Reference](tutorials/figlet-reference.md)
 - **Live terminals** → [Zones Reference](guides/zones-reference.md#pty-zones)
+- **Scripting/Automation** → [API Scripting Guide](guides/api-scripting.md)
 - **Spatial workspace** → [Middle Grid Example](examples/middle-grid.md)
 
 ### Looking for Reference?

--- a/docs/guides/api-scripting.md
+++ b/docs/guides/api-scripting.md
@@ -1,0 +1,715 @@
+# API Scripting Guide
+
+Control my-grid programmatically from Python, Bash, or any language that can open TCP sockets. The `--server` mode exposes the full command set for external automation.
+
+---
+
+## Quick Start
+
+### 1. Start my-grid with Server Mode
+
+```bash
+python mygrid.py --server
+```
+
+This enables:
+
+- **TCP socket** on port 8765 (configurable with `--port`)
+- **Unix FIFO** at `/tmp/mygrid.fifo` (Linux/macOS/WSL)
+
+### 2. Send Commands
+
+**Python:**
+
+```python
+import socket
+
+def send_command(cmd):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect(('localhost', 8765))
+    sock.sendall((cmd + '\n').encode())
+    response = sock.recv(4096).decode()
+    sock.close()
+    return response
+
+send_command(':goto 0 0')
+send_command(':text Hello World')
+```
+
+**Bash:**
+
+```bash
+echo ':rect 10 5' | nc localhost 8765
+```
+
+**FIFO (fire-and-forget):**
+
+```bash
+echo ':text Quick note' > /tmp/mygrid.fifo
+```
+
+---
+
+## Protocol Reference
+
+### TCP Socket Interface
+
+| Property     | Value                      |
+| ------------ | -------------------------- |
+| Default Port | 8765                       |
+| Protocol     | TCP                        |
+| Format       | Newline-delimited commands |
+| Response     | JSON                       |
+
+**Command Format:**
+
+```
+:command arg1 arg2\n
+```
+
+**Response Format:**
+
+```json
+{"status": "ok", "message": "Command executed"}
+{"status": "error", "message": "Unknown command: xyz"}
+```
+
+### Unix FIFO Interface
+
+| Property | Value                  |
+| -------- | ---------------------- |
+| Path     | `/tmp/mygrid.fifo`     |
+| Mode     | Write-only             |
+| Response | None (fire-and-forget) |
+
+The FIFO is ideal for quick commands where you don't need confirmation:
+
+```bash
+echo ':goto 50 50' > /tmp/mygrid.fifo
+echo ':text Marker' > /tmp/mygrid.fifo
+```
+
+### Command Line Options
+
+```bash
+python mygrid.py --server              # Enable API server
+python mygrid.py --server --port 9000  # Custom port
+python mygrid.py --server --no-fifo    # Disable FIFO (TCP only)
+python mygrid.py --server --headless   # No display (CI/CD mode)
+```
+
+---
+
+## Python Client Library
+
+Here's a reusable client class for Python scripts:
+
+```python
+#!/usr/bin/env python3
+"""my-grid API client library."""
+
+import socket
+import json
+import time
+
+class MyGridClient:
+    """Client for my-grid API server."""
+
+    def __init__(self, host='localhost', port=8765):
+        self.host = host
+        self.port = port
+
+    def send(self, command):
+        """Send command and return response."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(5.0)
+        try:
+            sock.connect((self.host, self.port))
+            sock.sendall((command + '\n').encode())
+            response = sock.recv(4096).decode()
+            sock.close()
+            return json.loads(response) if response.startswith('{') else response
+        except Exception as e:
+            return {'status': 'error', 'message': str(e)}
+
+    def goto(self, x, y):
+        """Move cursor to position."""
+        return self.send(f':goto {x} {y}')
+
+    def text(self, message):
+        """Write text at cursor."""
+        return self.send(f':text {message}')
+
+    def rect(self, width, height, char='#'):
+        """Draw rectangle at cursor."""
+        return self.send(f':rect {width} {height} {char}')
+
+    def clear(self):
+        """Clear the canvas."""
+        return self.send(':clear')
+
+    def save(self, filepath=None):
+        """Save project."""
+        if filepath:
+            return self.send(f':w {filepath}')
+        return self.send(':w')
+
+    def zone_create(self, name, x, y, width, height):
+        """Create a static zone."""
+        return self.send(f':zone create {name} {x} {y} {width} {height}')
+
+    def zone_pipe(self, name, width, height, command):
+        """Create a pipe zone."""
+        return self.send(f':zone pipe {name} {width} {height} {command}')
+
+    def zone_watch(self, name, width, height, interval, command):
+        """Create a watch zone."""
+        return self.send(f':zone watch {name} {width} {height} {interval} {command}')
+
+# Usage
+if __name__ == '__main__':
+    client = MyGridClient()
+    client.goto(0, 0)
+    client.text('Hello from Python!')
+    client.rect(20, 10)
+```
+
+---
+
+## Common Patterns
+
+### Pattern 1: Data Processing Pipeline
+
+Load data, transform it, and display on canvas:
+
+```python
+import json
+from mygrid_client import MyGridClient
+
+client = MyGridClient()
+
+# Load data
+with open('servers.json') as f:
+    servers = json.load(f)
+
+# Display in grid
+client.clear()
+y = 0
+for server in servers:
+    status = '✓' if server['online'] else '✗'
+    client.goto(0, y)
+    client.text(f"{status} {server['name']:20} {server['ip']}")
+    y += 1
+
+client.save('server-status.json')
+```
+
+### Pattern 2: Loops and Iteration
+
+Generate repetitive structures:
+
+```python
+client = MyGridClient()
+
+# Create coordinate grid
+for x in range(0, 100, 10):
+    for y in range(0, 100, 10):
+        client.goto(x, y)
+        client.text('+')
+
+# Draw grid lines
+for x in range(0, 100, 10):
+    client.send(f':line {x} 0 {x} 100 |')
+
+for y in range(0, 100, 10):
+    client.send(f':line 0 {y} 100 {y} -')
+```
+
+### Pattern 3: Conditional Formatting
+
+Apply different formatting based on data:
+
+```python
+def status_marker(status):
+    markers = {
+        'healthy': ('✓', 'green'),
+        'warning': ('!', 'yellow'),
+        'error': ('✗', 'red'),
+        'unknown': ('?', 'default')
+    }
+    return markers.get(status, markers['unknown'])
+
+for i, service in enumerate(services):
+    marker, color = status_marker(service['status'])
+    client.send(f':color {color}')
+    client.goto(0, i)
+    client.text(f"{marker} {service['name']}")
+
+client.send(':color off')  # Reset colors
+```
+
+### Pattern 4: Zone-Based Dashboards
+
+Create monitoring dashboards with zones:
+
+```python
+client = MyGridClient()
+
+# Clear and set up zones
+client.clear()
+
+# System metrics zone
+client.send(':zone watch SYSTEM 40 10 5s top -b -n1 | head -10')
+
+# Disk usage zone
+client.send(':zone watch DISK 40 8 30s df -h')
+
+# Git status zone
+client.send(':zone watch GIT 50 15 10s git status --short')
+
+# Log tail zone
+client.send(':zone watch LOGS 80 20 2s tail -20 /var/log/syslog')
+
+# Save layout
+client.save('dashboard.json')
+```
+
+### Pattern 5: Template Population
+
+Use templates to generate formatted output:
+
+```python
+from string import Template
+
+report_template = Template("""
+╔══════════════════════════════════════╗
+║  $title
+╠══════════════════════════════════════╣
+║  Generated: $date
+║  Author: $author
+╠══════════════════════════════════════╣
+║  Summary:
+║  - Total items: $total
+║  - Processed: $processed
+║  - Errors: $errors
+╚══════════════════════════════════════╝
+""")
+
+output = report_template.substitute(
+    title='Daily Report',
+    date='2025-01-04',
+    author='Automation',
+    total=150,
+    processed=148,
+    errors=2
+)
+
+for i, line in enumerate(output.strip().split('\n')):
+    client.goto(0, i)
+    client.text(line)
+```
+
+### Pattern 6: Batch Command Execution
+
+Execute commands from a file:
+
+```python
+#!/usr/bin/env python3
+"""Execute batch commands from file."""
+
+import sys
+from mygrid_client import MyGridClient
+
+def run_batch(filename):
+    client = MyGridClient()
+
+    with open(filename) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                print(f'> {line}')
+                response = client.send(line)
+                print(f'  {response}')
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: batch_commands.py <command-file>')
+        sys.exit(1)
+    run_batch(sys.argv[1])
+```
+
+**Example command file (`setup.txt`):**
+
+```
+# Clear and set up workspace
+:clear
+:goto 0 0
+:text Project Dashboard
+:goto 0 2
+:rect 80 20
+:zone watch STATUS 75 15 10s ./check-status.sh
+```
+
+---
+
+## Bash Scripting
+
+### Simple Command Sender
+
+```bash
+#!/bin/bash
+# mygrid-send - Send command to my-grid
+
+PORT=${MYGRID_PORT:-8765}
+HOST=${MYGRID_HOST:-localhost}
+
+if [ -z "$1" ]; then
+    echo "Usage: mygrid-send '<command>'"
+    exit 1
+fi
+
+echo "$1" | nc -q0 "$HOST" "$PORT"
+```
+
+### Pipe Input to Canvas
+
+```bash
+#!/bin/bash
+# mygrid-pipe - Pipe stdin to canvas region
+
+X=${1:-0}
+Y=${2:-0}
+PORT=${MYGRID_PORT:-8765}
+
+echo ":goto $X $Y" | nc -q0 localhost $PORT
+
+while IFS= read -r line; do
+    echo ":text $line" | nc -q0 localhost $PORT
+    ((Y++))
+    echo ":goto $X $Y" | nc -q0 localhost $PORT
+done
+```
+
+**Usage:**
+
+```bash
+ls -la | ./mygrid-pipe 10 5
+git log --oneline -10 | ./mygrid-pipe 0 0
+```
+
+### FIFO Helper
+
+```bash
+#!/bin/bash
+# mygrid-fifo - Send commands via FIFO (faster, no response)
+
+FIFO="/tmp/mygrid.fifo"
+
+if [ ! -p "$FIFO" ]; then
+    echo "Error: my-grid FIFO not available. Start with --server"
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    # Read from stdin
+    while IFS= read -r line; do
+        echo "$line" > "$FIFO"
+    done
+else
+    echo "$1" > "$FIFO"
+fi
+```
+
+---
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+name: Update Architecture Diagram
+
+on:
+  push:
+    paths:
+      - "docs/architecture/**"
+
+jobs:
+  update-diagram:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Generate diagram
+        run: |
+          python mygrid.py --server --headless &
+          MYGRID_PID=$!
+          sleep 2
+
+          python scripts/generate_architecture.py
+          echo ':w docs/architecture.json' | nc localhost 8765
+
+          kill $MYGRID_PID
+
+      - name: Commit changes
+        run: |
+          git config user.name 'GitHub Actions'
+          git config user.email 'actions@github.com'
+          git add docs/architecture.json
+          git diff --staged --quiet || git commit -m 'Update architecture diagram'
+          git push
+```
+
+### Local Automation Script
+
+```bash
+#!/bin/bash
+# update_diagram.sh - Update and save diagram
+
+set -e
+
+# Start headless my-grid
+python mygrid.py diagram.json --server --headless &
+MYGRID_PID=$!
+trap "kill $MYGRID_PID 2>/dev/null" EXIT
+
+sleep 2
+
+# Run update script
+python scripts/update_components.py
+
+# Save
+echo ':w' | nc -q1 localhost 8765
+
+echo "Diagram updated successfully"
+```
+
+---
+
+## Error Handling
+
+### Python Error Handling
+
+```python
+import socket
+import json
+
+class MyGridError(Exception):
+    """my-grid API error."""
+    pass
+
+def send_command(cmd, timeout=5.0):
+    """Send command with error handling."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+
+    try:
+        sock.connect(('localhost', 8765))
+    except ConnectionRefusedError:
+        raise MyGridError('Cannot connect - is my-grid running with --server?')
+    except socket.timeout:
+        raise MyGridError('Connection timed out')
+
+    try:
+        sock.sendall((cmd + '\n').encode())
+        response = sock.recv(4096).decode()
+    except socket.timeout:
+        raise MyGridError(f'Command timed out: {cmd}')
+    finally:
+        sock.close()
+
+    # Parse response
+    try:
+        data = json.loads(response)
+        if data.get('status') == 'error':
+            raise MyGridError(data.get('message', 'Unknown error'))
+        return data
+    except json.JSONDecodeError:
+        return response  # Plain text response
+```
+
+### Retry Logic
+
+```python
+import time
+
+def send_with_retry(cmd, max_retries=3, delay=1.0):
+    """Send command with automatic retry."""
+    for attempt in range(max_retries):
+        try:
+            return send_command(cmd)
+        except MyGridError as e:
+            if attempt < max_retries - 1:
+                print(f'Retry {attempt + 1}/{max_retries}: {e}')
+                time.sleep(delay)
+            else:
+                raise
+```
+
+---
+
+## Best Practices
+
+### 1. Connection Management
+
+For scripts sending many commands, consider connection pooling:
+
+```python
+class MyGridSession:
+    """Persistent connection for batch operations."""
+
+    def __init__(self, host='localhost', port=8765):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.connect((host, port))
+
+    def send(self, cmd):
+        self.sock.sendall((cmd + '\n').encode())
+        return self.sock.recv(4096).decode()
+
+    def close(self):
+        self.sock.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+# Usage
+with MyGridSession() as session:
+    for i in range(100):
+        session.send(f':goto 0 {i}')
+        session.send(f':text Line {i}')
+```
+
+### 2. Rate Limiting
+
+Add small delays for visual operations:
+
+```python
+import time
+
+def animate_text(client, text, x, y, delay=0.05):
+    """Type text with animation effect."""
+    for i, char in enumerate(text):
+        client.goto(x + i, y)
+        client.text(char)
+        time.sleep(delay)
+```
+
+### 3. Coordinate Planning
+
+Plan your canvas layout before scripting:
+
+```python
+# Define layout constants
+HEADER_Y = 0
+CONTENT_Y = 3
+SIDEBAR_X = 60
+ZONE_WIDTH = 50
+ZONE_HEIGHT = 15
+
+# Use consistently
+client.goto(0, HEADER_Y)
+client.text('=== Dashboard ===')
+
+client.goto(0, CONTENT_Y)
+client.zone_create('MAIN', 0, CONTENT_Y, ZONE_WIDTH, ZONE_HEIGHT)
+
+client.goto(SIDEBAR_X, CONTENT_Y)
+client.zone_create('SIDEBAR', SIDEBAR_X, CONTENT_Y, 30, ZONE_HEIGHT)
+```
+
+### 4. Use Zones for Dynamic Content
+
+Prefer zones over manual refresh loops:
+
+```python
+# Good: Let my-grid handle refresh
+client.send(':zone watch LOGS 80 20 2s tail -20 app.log')
+
+# Avoid: Manual refresh loop
+# while True:
+#     output = subprocess.check_output(['tail', '-20', 'app.log'])
+#     # Send each line...
+#     time.sleep(2)
+```
+
+---
+
+## Troubleshooting
+
+### Connection Refused
+
+```
+Error: Cannot connect - is my-grid running with --server?
+```
+
+**Solution:** Start my-grid with `--server` flag:
+
+```bash
+python mygrid.py --server
+```
+
+### Port Already in Use
+
+```
+Error: Address already in use
+```
+
+**Solution:** Use a different port:
+
+```bash
+python mygrid.py --server --port 9000
+```
+
+Update your client:
+
+```python
+client = MyGridClient(port=9000)
+```
+
+### FIFO Not Available
+
+```
+Error: my-grid FIFO not available
+```
+
+**Solutions:**
+
+1. Ensure my-grid is running with `--server`
+2. Check the FIFO exists: `ls -la /tmp/mygrid.fifo`
+3. FIFO is not available on Windows (use TCP instead)
+
+### Commands Not Executing
+
+Ensure commands are newline-terminated:
+
+```python
+# Correct
+sock.sendall((cmd + '\n').encode())
+
+# Wrong - missing newline
+sock.sendall(cmd.encode())
+```
+
+---
+
+## See Also
+
+- [Zones Reference](zones-reference.md) - Complete zone command reference
+- [CLAUDE.md](../../CLAUDE.md) - Full command reference
+- [mygrid-ctl](../../mygrid-ctl.py) - Command-line control utility
+- [Example Scripts](../../scripts/) - Ready-to-use automation scripts
+
+---
+
+**[Back to Documentation Index](../README.md)**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,60 @@
+# my-grid Scripts
+
+Ready-to-use automation scripts for the my-grid API.
+
+## Prerequisites
+
+Start my-grid with server mode enabled:
+
+```bash
+python mygrid.py --server
+```
+
+## Available Scripts
+
+### Python Scripts
+
+| Script              | Description                        |
+| ------------------- | ---------------------------------- |
+| `mygrid_client.py`  | Reusable Python client library     |
+| `import_csv.py`     | Import CSV data as table on canvas |
+| `generate_grid.py`  | Generate coordinate grid lines     |
+| `batch_commands.py` | Execute commands from a file       |
+
+### Bash Scripts
+
+| Script        | Description                    |
+| ------------- | ------------------------------ |
+| `mygrid-send` | Send single command to my-grid |
+| `mygrid-pipe` | Pipe stdin to canvas region    |
+
+## Quick Examples
+
+### Python
+
+```python
+from mygrid_client import MyGridClient
+
+client = MyGridClient()
+client.goto(0, 0)
+client.text('Hello World!')
+client.rect(20, 10)
+```
+
+### Bash
+
+```bash
+# Single command
+./mygrid-send ':text Hello'
+
+# Pipe output
+ls -la | ./mygrid-pipe 0 0
+
+# Batch commands
+./batch_commands.py commands.txt
+```
+
+## See Also
+
+- [API Scripting Guide](../docs/guides/api-scripting.md) - Full documentation
+- [Zones Reference](../docs/guides/zones-reference.md) - Zone commands

--- a/scripts/batch_commands.py
+++ b/scripts/batch_commands.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Execute batch commands from a file.
+
+Usage:
+    python batch_commands.py <command-file>
+    python batch_commands.py -  # Read from stdin
+
+Command file format:
+    # Comments start with #
+    :goto 0 0
+    :text Hello World
+    :rect 20 10
+
+Examples:
+    python batch_commands.py setup.txt
+    echo ':text Quick' | python batch_commands.py -
+"""
+
+import sys
+from pathlib import Path
+
+try:
+    from mygrid_client import MyGridClient, MyGridError
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from mygrid_client import MyGridClient, MyGridError
+
+
+def run_batch(source):
+    """Execute commands from file or stdin."""
+    client = MyGridClient()
+
+    if source == "-":
+        lines = sys.stdin.readlines()
+    else:
+        with open(source) as f:
+            lines = f.readlines()
+
+    executed = 0
+    skipped = 0
+
+    for line in lines:
+        line = line.strip()
+
+        # Skip empty lines and comments
+        if not line or line.startswith("#"):
+            skipped += 1
+            continue
+
+        print(f"> {line}")
+        try:
+            response = client.send(line)
+            if response:
+                print(f"  {response}")
+            executed += 1
+        except MyGridError as e:
+            print(f"  Error: {e}")
+
+    print(f"\nExecuted: {executed}, Skipped: {skipped}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    source = sys.argv[1]
+
+    if source != "-" and not Path(source).exists():
+        print(f"File not found: {source}")
+        sys.exit(1)
+
+    try:
+        run_batch(source)
+    except MyGridError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_grid.py
+++ b/scripts/generate_grid.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Generate coordinate grid on my-grid canvas.
+
+Usage:
+    python generate_grid.py [width] [height] [spacing]
+
+Examples:
+    python generate_grid.py              # Default 100x100, spacing 10
+    python generate_grid.py 200 100      # Custom size
+    python generate_grid.py 100 100 20   # Custom spacing
+"""
+
+import sys
+from pathlib import Path
+
+try:
+    from mygrid_client import MyGridClient, MyGridError
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from mygrid_client import MyGridClient, MyGridError
+
+
+def generate_grid(width=100, height=100, spacing=10):
+    """Generate coordinate grid on canvas."""
+    client = MyGridClient()
+
+    print(f"Generating {width}x{height} grid with spacing {spacing}...")
+
+    # Draw intersection points
+    for x in range(0, width + 1, spacing):
+        for y in range(0, height + 1, spacing):
+            client.goto(x, y)
+            client.text("+")
+
+    # Draw horizontal lines
+    for y in range(0, height + 1, spacing):
+        for x in range(0, width + 1):
+            if x % spacing != 0:  # Skip intersection points
+                client.goto(x, y)
+                client.text("-")
+
+    # Draw vertical lines
+    for x in range(0, width + 1, spacing):
+        for y in range(0, height + 1):
+            if y % spacing != 0:  # Skip intersection points
+                client.goto(x, y)
+                client.text("|")
+
+    # Add coordinate labels
+    for x in range(0, width + 1, spacing):
+        client.goto(x, -1)
+        client.text(str(x))
+
+    for y in range(spacing, height + 1, spacing):
+        client.goto(-3, y)
+        client.text(str(y).rjust(2))
+
+    print(f"Grid generated: {width}x{height}")
+
+
+def main():
+    width = int(sys.argv[1]) if len(sys.argv) > 1 else 100
+    height = int(sys.argv[2]) if len(sys.argv) > 2 else 100
+    spacing = int(sys.argv[3]) if len(sys.argv) > 3 else 10
+
+    try:
+        generate_grid(width, height, spacing)
+    except MyGridError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/import_csv.py
+++ b/scripts/import_csv.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Import CSV data as a formatted table on my-grid canvas.
+
+Usage:
+    python import_csv.py data.csv [x] [y]
+
+Examples:
+    python import_csv.py servers.csv
+    python import_csv.py data.csv 10 5
+"""
+
+import sys
+import csv
+from pathlib import Path
+
+try:
+    from mygrid_client import MyGridClient, MyGridError
+except ImportError:
+    # Allow running from different directory
+    sys.path.insert(0, str(Path(__file__).parent))
+    from mygrid_client import MyGridClient, MyGridError
+
+
+def format_table(rows, padding=2):
+    """Format rows as aligned table with borders."""
+    if not rows:
+        return []
+
+    # Calculate column widths
+    num_cols = len(rows[0])
+    col_widths = [0] * num_cols
+    for row in rows:
+        for i, cell in enumerate(row):
+            col_widths[i] = max(col_widths[i], len(str(cell)))
+
+    # Add padding
+    col_widths = [w + padding for w in col_widths]
+
+    # Build output lines
+    lines = []
+
+    # Top border
+    border = "+" + "+".join("-" * w for w in col_widths) + "+"
+    lines.append(border)
+
+    for i, row in enumerate(rows):
+        # Data row
+        cells = []
+        for j, cell in enumerate(row):
+            cells.append(str(cell).ljust(col_widths[j] - padding).center(col_widths[j]))
+        lines.append("|" + "|".join(cells) + "|")
+
+        # Header separator
+        if i == 0:
+            lines.append(border.replace("-", "="))
+
+    # Bottom border
+    lines.append(border)
+
+    return lines
+
+
+def import_csv(filepath, start_x=0, start_y=0):
+    """Import CSV file to my-grid canvas."""
+    # Read CSV
+    with open(filepath, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    if not rows:
+        print("CSV file is empty")
+        return
+
+    print(f"Loaded {len(rows)} rows, {len(rows[0])} columns")
+
+    # Format as table
+    table_lines = format_table(rows)
+
+    # Send to my-grid
+    client = MyGridClient()
+
+    for i, line in enumerate(table_lines):
+        client.goto(start_x, start_y + i)
+        client.text(line)
+
+    print(f"Table written at ({start_x}, {start_y})")
+    print(f"Size: {len(table_lines[0])} x {len(table_lines)}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    start_x = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+    start_y = int(sys.argv[3]) if len(sys.argv) > 3 else 0
+
+    if not Path(filepath).exists():
+        print(f"File not found: {filepath}")
+        sys.exit(1)
+
+    try:
+        import_csv(filepath, start_x, start_y)
+    except MyGridError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mygrid-pipe
+++ b/scripts/mygrid-pipe
@@ -1,0 +1,36 @@
+#!/bin/bash
+# mygrid-pipe - Pipe stdin to my-grid canvas
+#
+# Usage:
+#   command | mygrid-pipe [x] [y]
+#   ls -la | mygrid-pipe 0 0
+#   git log --oneline -10 | mygrid-pipe 10 5
+#
+# Environment:
+#   MYGRID_HOST - Server host (default: localhost)
+#   MYGRID_PORT - Server port (default: 8765)
+
+set -e
+
+X=${1:-0}
+Y=${2:-0}
+PORT=${MYGRID_PORT:-8765}
+HOST=${MYGRID_HOST:-localhost}
+
+# Check connection
+if ! echo ':goto 0 0' | nc -q0 "$HOST" "$PORT" >/dev/null 2>&1; then
+    echo "Error: Cannot connect to $HOST:$PORT"
+    echo "Is my-grid running with --server?"
+    exit 1
+fi
+
+# Read and send each line
+LINE_NUM=0
+while IFS= read -r line; do
+    CURRENT_Y=$((Y + LINE_NUM))
+    echo ":goto $X $CURRENT_Y" | nc -q0 "$HOST" "$PORT" >/dev/null
+    echo ":text $line" | nc -q0 "$HOST" "$PORT" >/dev/null
+    ((LINE_NUM++))
+done
+
+echo "Wrote $LINE_NUM lines at ($X, $Y)"

--- a/scripts/mygrid-send
+++ b/scripts/mygrid-send
@@ -1,0 +1,37 @@
+#!/bin/bash
+# mygrid-send - Send command to my-grid API server
+#
+# Usage:
+#   mygrid-send '<command>'
+#   mygrid-send ':text Hello World'
+#   mygrid-send ':goto 10 20'
+#
+# Environment:
+#   MYGRID_HOST - Server host (default: localhost)
+#   MYGRID_PORT - Server port (default: 8765)
+
+set -e
+
+PORT=${MYGRID_PORT:-8765}
+HOST=${MYGRID_HOST:-localhost}
+
+if [ -z "$1" ]; then
+    echo "Usage: mygrid-send '<command>'"
+    echo ""
+    echo "Examples:"
+    echo "  mygrid-send ':text Hello'"
+    echo "  mygrid-send ':goto 10 20'"
+    echo "  mygrid-send ':rect 20 10'"
+    echo ""
+    echo "Environment:"
+    echo "  MYGRID_HOST=$HOST"
+    echo "  MYGRID_PORT=$PORT"
+    exit 1
+fi
+
+# Send command via netcat
+echo "$1" | nc -q0 "$HOST" "$PORT" 2>/dev/null || {
+    echo "Error: Cannot connect to $HOST:$PORT"
+    echo "Is my-grid running with --server?"
+    exit 1
+}

--- a/scripts/mygrid_client.py
+++ b/scripts/mygrid_client.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+my-grid API Client Library
+
+Reusable client for controlling my-grid via TCP socket.
+
+Usage:
+    from mygrid_client import MyGridClient
+
+    client = MyGridClient()
+    client.goto(0, 0)
+    client.text('Hello World!')
+    client.rect(20, 10)
+"""
+
+import socket
+import json
+
+
+class MyGridError(Exception):
+    """Error from my-grid API."""
+
+    pass
+
+
+class MyGridClient:
+    """Client for my-grid API server."""
+
+    def __init__(self, host="localhost", port=8765, timeout=5.0):
+        """
+        Initialize client.
+
+        Args:
+            host: Server hostname (default: localhost)
+            port: Server port (default: 8765)
+            timeout: Socket timeout in seconds (default: 5.0)
+        """
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def send(self, command):
+        """
+        Send command and return response.
+
+        Args:
+            command: Command string (e.g., ':goto 0 0')
+
+        Returns:
+            dict or str: Parsed JSON response or raw string
+
+        Raises:
+            MyGridError: On connection or command error
+        """
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+
+        try:
+            sock.connect((self.host, self.port))
+        except ConnectionRefusedError:
+            raise MyGridError(
+                f"Cannot connect to {self.host}:{self.port}. "
+                "Is my-grid running with --server?"
+            )
+        except socket.timeout:
+            raise MyGridError("Connection timed out")
+
+        try:
+            sock.sendall((command + "\n").encode())
+            response = sock.recv(4096).decode()
+        except socket.timeout:
+            raise MyGridError(f"Command timed out: {command}")
+        finally:
+            sock.close()
+
+        # Parse response
+        if response.startswith("{"):
+            try:
+                data = json.loads(response)
+                if data.get("status") == "error":
+                    raise MyGridError(data.get("message", "Unknown error"))
+                return data
+            except json.JSONDecodeError:
+                pass
+        return response.strip()
+
+    # Navigation commands
+    def goto(self, x, y):
+        """Move cursor to (x, y)."""
+        return self.send(f":goto {x} {y}")
+
+    # Drawing commands
+    def text(self, message):
+        """Write text at cursor position."""
+        return self.send(f":text {message}")
+
+    def rect(self, width, height, char="#"):
+        """Draw rectangle at cursor."""
+        return self.send(f":rect {width} {height} {char}")
+
+    def line(self, x2, y2, char=None):
+        """Draw line from cursor to (x2, y2)."""
+        if char:
+            return self.send(f":line {x2} {y2} {char}")
+        return self.send(f":line {x2} {y2}")
+
+    def clear(self):
+        """Clear the entire canvas."""
+        return self.send(":clear")
+
+    # Color commands
+    def color(self, fg, bg=None):
+        """Set drawing color."""
+        if bg:
+            return self.send(f":color {fg} {bg}")
+        return self.send(f":color {fg}")
+
+    def color_off(self):
+        """Reset to default colors."""
+        return self.send(":color off")
+
+    # File commands
+    def save(self, filepath=None):
+        """Save project to file."""
+        if filepath:
+            return self.send(f":w {filepath}")
+        return self.send(":w")
+
+    def load(self, filepath):
+        """Load project from file."""
+        return self.send(f":e {filepath}")
+
+    # Zone commands
+    def zone_create(self, name, x, y, width, height):
+        """Create a static zone."""
+        return self.send(f":zone create {name} {x} {y} {width} {height}")
+
+    def zone_pipe(self, name, width, height, command):
+        """Create a pipe zone (one-shot command)."""
+        return self.send(f":zone pipe {name} {width} {height} {command}")
+
+    def zone_watch(self, name, width, height, interval, command):
+        """Create a watch zone (periodic refresh)."""
+        return self.send(f":zone watch {name} {width} {height} {interval} {command}")
+
+    def zone_delete(self, name):
+        """Delete a zone."""
+        return self.send(f":zone delete {name}")
+
+    def zone_goto(self, name):
+        """Jump cursor to zone center."""
+        return self.send(f":zone goto {name}")
+
+    def zone_refresh(self, name):
+        """Manually refresh a zone."""
+        return self.send(f":zone refresh {name}")
+
+    # Layout commands
+    def layout_load(self, name, clear=False):
+        """Load a layout."""
+        if clear:
+            return self.send(f":layout load {name} --clear")
+        return self.send(f":layout load {name}")
+
+    def layout_save(self, name, description=None):
+        """Save current zones as layout."""
+        if description:
+            return self.send(f":layout save {name} {description}")
+        return self.send(f":layout save {name}")
+
+
+class MyGridSession:
+    """
+    Persistent connection for batch operations.
+
+    More efficient than MyGridClient for sending many commands.
+
+    Usage:
+        with MyGridSession() as session:
+            for i in range(100):
+                session.send(f':goto 0 {i}')
+                session.send(f':text Line {i}')
+    """
+
+    def __init__(self, host="localhost", port=8765, timeout=30.0):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.sock = None
+
+    def connect(self):
+        """Establish connection."""
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.settimeout(self.timeout)
+        self.sock.connect((self.host, self.port))
+
+    def send(self, command):
+        """Send command over persistent connection."""
+        if not self.sock:
+            raise MyGridError("Not connected")
+        self.sock.sendall((command + "\n").encode())
+        return self.sock.recv(4096).decode().strip()
+
+    def close(self):
+        """Close connection."""
+        if self.sock:
+            self.sock.close()
+            self.sock = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+if __name__ == "__main__":
+    # Demo usage
+    print("my-grid API Client Demo")
+    print("=" * 40)
+
+    try:
+        client = MyGridClient()
+
+        print("Moving to origin...")
+        client.goto(0, 0)
+
+        print("Writing text...")
+        client.text("Hello from mygrid_client.py!")
+
+        print("Drawing rectangle...")
+        client.goto(0, 2)
+        client.rect(30, 5)
+
+        print("Done!")
+
+    except MyGridError as e:
+        print(f"Error: {e}")
+        print("Make sure my-grid is running with --server")


### PR DESCRIPTION
## Summary

Comprehensive documentation for scripting my-grid via the API server, addressing Issue #51.

### New Documentation
- **docs/guides/api-scripting.md** (715 lines): Complete guide covering:
  - Protocol reference (TCP socket, Unix FIFO)
  - Python client library with examples
  - Common patterns (data processing, loops, templates, CI/CD)
  - Bash scripting helpers
  - Error handling and troubleshooting

### New Scripts (scripts/)
| Script | Description |
|--------|-------------|
| `mygrid_client.py` | Reusable Python client library |
| `import_csv.py` | Import CSV data as formatted tables |
| `generate_grid.py` | Generate coordinate grid overlay |
| `batch_commands.py` | Execute commands from file |
| `mygrid-send` | Bash helper for single commands |
| `mygrid-pipe` | Pipe stdin to canvas region |

### Updated Documentation
- **README.md**: Added "Scripting & Automation" section
- **CLAUDE.md**: Added Python client examples and resource links
- **docs/README.md**: Added API scripting to navigation

## Test Plan
- [x] All 648 tests pass
- [x] Scripts are executable (chmod +x)
- [x] Documentation links work
- [ ] Manual test: Run mygrid with --server and test client library

## Closes
- Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)