### PR TITLE
refactor: Replace Any types with specific type hints in layouts.py

### DIFF
--- a/src/layouts.py
+++ b/src/layouts.py
@@ -9,22 +9,25 @@ import os
 import yaml
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING
 
 from zones import ZoneManager, ZoneExecutor, ZoneType, ZoneConfig
+
+if TYPE_CHECKING:
+    from zones import PTYHandler, FIFOHandler, SocketHandler
 
 
 # Default layouts directory
 def get_layouts_dir() -> Path:
     """Get the layouts directory, creating if needed."""
-    if os.name == 'nt':
+    if os.name == "nt":
         # Windows: use APPDATA
-        base = Path(os.environ.get('APPDATA', Path.home() / 'AppData' / 'Roaming'))
+        base = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
     else:
         # Unix: use XDG_CONFIG_HOME or ~/.config
-        base = Path(os.environ.get('XDG_CONFIG_HOME', Path.home() / '.config'))
+        base = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
 
-    layouts_dir = base / 'mygrid' / 'layouts'
+    layouts_dir = base / "mygrid" / "layouts"
     layouts_dir.mkdir(parents=True, exist_ok=True)
     return layouts_dir
 
@@ -32,6 +35,7 @@ def get_layouts_dir() -> Path:
 @dataclass
 class LayoutZone:
     """Zone definition within a layout."""
+
     name: str
     zone_type: str  # static, pipe, watch, pty, fifo, socket, pager
     x: int
@@ -103,6 +107,7 @@ class LayoutZone:
 @dataclass
 class Layout:
     """A workspace layout configuration."""
+
     name: str
     description: str
     zones: list[LayoutZone]
@@ -166,7 +171,7 @@ class LayoutManager:
     def _layout_path(self, name: str) -> Path:
         """Get path for a layout file."""
         # Sanitize name
-        safe_name = "".join(c for c in name if c.isalnum() or c in '-_').lower()
+        safe_name = "".join(c for c in name if c.isalnum() or c in "-_").lower()
         return self.layouts_dir / f"{safe_name}.yaml"
 
     def save(self, layout: Layout) -> Path:
@@ -176,7 +181,7 @@ class LayoutManager:
         Returns the path where it was saved.
         """
         path = self._layout_path(layout.name)
-        path.write_text(layout.to_yaml(), encoding='utf-8')
+        path.write_text(layout.to_yaml(), encoding="utf-8")
         return path
 
     def load(self, name: str) -> Layout | None:
@@ -190,7 +195,7 @@ class LayoutManager:
             return None
 
         try:
-            yaml_str = path.read_text(encoding='utf-8')
+            yaml_str = path.read_text(encoding="utf-8")
             return Layout.from_yaml(yaml_str)
         except Exception:
             return None
@@ -216,7 +221,7 @@ class LayoutManager:
         layouts = []
         for path in self.layouts_dir.glob("*.yaml"):
             try:
-                yaml_str = path.read_text(encoding='utf-8')
+                yaml_str = path.read_text(encoding="utf-8")
                 data = yaml.safe_load(yaml_str)
                 name = data.get("name", path.stem)
                 desc = data.get("description", "")
@@ -287,9 +292,9 @@ class LayoutManager:
         layout: Layout,
         zone_manager: ZoneManager,
         zone_executor: ZoneExecutor,
-        pty_handler: Any | None = None,
-        fifo_handler: Any | None = None,
-        socket_handler: Any | None = None,
+        pty_handler: "PTYHandler | None" = None,
+        fifo_handler: "FIFOHandler | None" = None,
+        socket_handler: "SocketHandler | None" = None,
         clear_existing: bool = False,
     ) -> tuple[int, list[str]]:
         """
@@ -365,6 +370,7 @@ class LayoutManager:
                 elif zone_type == ZoneType.PAGER and lz.file_path:
                     # Load pager content
                     from zones import load_pager_content
+
                     if not load_pager_content(zone, use_wsl=False):
                         errors.append(f"Failed to load pager content for '{lz.name}'")
 
@@ -388,36 +394,48 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="LOGS",
                 zone_type="watch",
-                x=0, y=0, width=80, height=15,
+                x=0,
+                y=0,
+                width=80,
+                height=15,
                 command="dmesg | tail -12",
                 interval=10,
                 bookmark="l",
-                description="System logs"
+                description="System logs",
             ),
             LayoutZone(
                 name="PROCESSES",
                 zone_type="watch",
-                x=0, y=16, width=80, height=12,
+                x=0,
+                y=16,
+                width=80,
+                height=12,
                 command="ps aux --sort=-%cpu | head -10",
                 interval=5,
                 bookmark="p",
-                description="Top CPU processes"
+                description="Top CPU processes",
             ),
             LayoutZone(
                 name="DISK",
                 zone_type="watch",
-                x=85, y=0, width=45, height=10,
+                x=85,
+                y=0,
+                width=45,
+                height=10,
                 command="df -h | head -8",
                 interval=30,
                 bookmark="d",
-                description="Disk usage"
+                description="Disk usage",
             ),
             LayoutZone(
                 name="TERMINAL",
                 zone_type="pty",
-                x=85, y=11, width=60, height=18,
+                x=85,
+                y=11,
+                width=60,
+                height=18,
                 bookmark="t",
-                description="Interactive terminal"
+                description="Interactive terminal",
             ),
         ],
     ),
@@ -428,27 +446,36 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="GIT",
                 zone_type="watch",
-                x=0, y=0, width=50, height=12,
+                x=0,
+                y=0,
+                width=50,
+                height=12,
                 command="git status --short 2>/dev/null || echo 'Not a git repo'",
                 interval=5,
                 bookmark="g",
-                description="Git status"
+                description="Git status",
             ),
             LayoutZone(
                 name="FILES",
                 zone_type="watch",
-                x=0, y=13, width=50, height=15,
+                x=0,
+                y=13,
+                width=50,
+                height=15,
                 command="ls -la | head -14",
                 interval=10,
                 bookmark="f",
-                description="Directory listing"
+                description="Directory listing",
             ),
             LayoutZone(
                 name="EDITOR",
                 zone_type="pty",
-                x=55, y=0, width=80, height=28,
+                x=55,
+                y=0,
+                width=80,
+                height=28,
                 bookmark="e",
-                description="Editor terminal"
+                description="Editor terminal",
             ),
         ],
     ),
@@ -459,38 +486,50 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="CPU",
                 zone_type="watch",
-                x=0, y=0, width=40, height=8,
+                x=0,
+                y=0,
+                width=40,
+                height=8,
                 command="uptime",
                 interval=5,
                 bookmark="c",
-                description="CPU load"
+                description="CPU load",
             ),
             LayoutZone(
                 name="MEMORY",
                 zone_type="watch",
-                x=0, y=9, width=40, height=8,
+                x=0,
+                y=9,
+                width=40,
+                height=8,
                 command="free -h | head -3",
                 interval=5,
                 bookmark="m",
-                description="Memory usage"
+                description="Memory usage",
             ),
             LayoutZone(
                 name="NETWORK",
                 zone_type="watch",
-                x=45, y=0, width=50, height=12,
+                x=45,
+                y=0,
+                width=50,
+                height=12,
                 command="netstat -tuln 2>/dev/null | head -10 || ss -tuln | head -10",
                 interval=10,
                 bookmark="n",
-                description="Network connections"
+                description="Network connections",
             ),
             LayoutZone(
                 name="DISK",
                 zone_type="watch",
-                x=45, y=13, width=50, height=8,
+                x=45,
+                y=13,
+                width=50,
+                height=8,
                 command="df -h | grep -E '^/dev' | head -5",
                 interval=30,
                 bookmark="d",
-                description="Disk usage"
+                description="Disk usage",
             ),
         ],
     ),
@@ -501,47 +540,62 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="TIME",
                 zone_type="watch",
-                x=0, y=0, width=40, height=6,
+                x=0,
+                y=0,
+                width=40,
+                height=6,
                 command="date '+%A, %B %d, %Y%n%H:%M:%S %Z'; echo '---'; uptime -p",
                 interval=1,
                 bookmark="t",
-                description="Current time and uptime"
+                description="Current time and uptime",
             ),
             LayoutZone(
                 name="MEMORY",
                 zone_type="watch",
-                x=0, y=7, width=40, height=8,
+                x=0,
+                y=7,
+                width=40,
+                height=8,
                 command="free -h",
                 interval=5,
                 bookmark="m",
-                description="Memory usage"
+                description="Memory usage",
             ),
             LayoutZone(
                 name="DISK",
                 zone_type="watch",
-                x=0, y=16, width=40, height=10,
+                x=0,
+                y=16,
+                width=40,
+                height=10,
                 command="df -h / /home 2>/dev/null | grep -v tmpfs || df -h | head -5",
                 interval=30,
                 bookmark="d",
-                description="Disk usage"
+                description="Disk usage",
             ),
             LayoutZone(
                 name="PROCESSES",
                 zone_type="watch",
-                x=45, y=0, width=60, height=15,
+                x=45,
+                y=0,
+                width=60,
+                height=15,
                 command="ps aux --sort=-%mem | head -12",
                 interval=5,
                 bookmark="p",
-                description="Top processes by memory"
+                description="Top processes by memory",
             ),
             LayoutZone(
                 name="NETWORK",
                 zone_type="watch",
-                x=45, y=16, width=60, height=10,
+                x=45,
+                y=16,
+                width=60,
+                height=10,
                 command="ss -s 2>/dev/null || netstat -s | head -10",
                 interval=10,
                 bookmark="n",
-                description="Network statistics"
+                description="Network statistics",
             ),
         ],
     ),
@@ -552,44 +606,59 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="SYSLOG",
                 zone_type="watch",
-                x=0, y=0, width=80, height=12,
+                x=0,
+                y=0,
+                width=80,
+                height=12,
                 command="journalctl -n 10 --no-pager 2>/dev/null || tail -10 /var/log/syslog 2>/dev/null || echo 'No syslog access'",
                 interval=5,
                 bookmark="s",
-                description="System log"
+                description="System log",
             ),
             LayoutZone(
                 name="AUTH",
                 zone_type="watch",
-                x=0, y=13, width=80, height=10,
+                x=0,
+                y=13,
+                width=80,
+                height=10,
                 command="journalctl -n 8 -t sshd --no-pager 2>/dev/null || tail -8 /var/log/auth.log 2>/dev/null || echo 'No auth log'",
                 interval=10,
                 bookmark="a",
-                description="Authentication log"
+                description="Authentication log",
             ),
             LayoutZone(
                 name="DMESG",
                 zone_type="watch",
-                x=0, y=24, width=80, height=10,
+                x=0,
+                y=24,
+                width=80,
+                height=10,
                 command="dmesg | tail -8",
                 interval=15,
                 bookmark="d",
-                description="Kernel messages"
+                description="Kernel messages",
             ),
             LayoutZone(
                 name="EVENTS",
                 zone_type="fifo",
-                x=85, y=0, width=50, height=20,
+                x=85,
+                y=0,
+                width=50,
+                height=20,
                 path="/tmp/log-events.fifo",
                 bookmark="e",
-                description="Custom event stream"
+                description="Custom event stream",
             ),
             LayoutZone(
                 name="TERMINAL",
                 zone_type="pty",
-                x=85, y=21, width=50, height=14,
+                x=85,
+                y=21,
+                width=50,
+                height=14,
                 bookmark="t",
-                description="Log exploration terminal"
+                description="Log exploration terminal",
             ),
         ],
     ),
@@ -600,36 +669,48 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="CONTAINERS",
                 zone_type="watch",
-                x=0, y=0, width=90, height=12,
+                x=0,
+                y=0,
+                width=90,
+                height=12,
                 command="docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null || echo 'Docker not available'",
                 interval=5,
                 bookmark="c",
-                description="Running containers"
+                description="Running containers",
             ),
             LayoutZone(
                 name="STATS",
                 zone_type="watch",
-                x=0, y=13, width=90, height=12,
+                x=0,
+                y=13,
+                width=90,
+                height=12,
                 command="docker stats --no-stream --format 'table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}' 2>/dev/null || echo 'Docker not available'",
                 interval=5,
                 bookmark="s",
-                description="Container stats"
+                description="Container stats",
             ),
             LayoutZone(
                 name="IMAGES",
                 zone_type="watch",
-                x=0, y=26, width=90, height=8,
+                x=0,
+                y=26,
+                width=90,
+                height=8,
                 command="docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.Size}}' | head -8 2>/dev/null",
                 interval=30,
                 bookmark="i",
-                description="Docker images"
+                description="Docker images",
             ),
             LayoutZone(
                 name="TERMINAL",
                 zone_type="pty",
-                x=95, y=0, width=60, height=34,
+                x=95,
+                y=0,
+                width=60,
+                height=34,
                 bookmark="t",
-                description="Docker CLI terminal"
+                description="Docker CLI terminal",
             ),
         ],
     ),
@@ -640,45 +721,60 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="INTERFACES",
                 zone_type="watch",
-                x=0, y=0, width=50, height=12,
+                x=0,
+                y=0,
+                width=50,
+                height=12,
                 command="ip -br addr 2>/dev/null || ifconfig | grep -E '^[a-z]|inet '",
                 interval=10,
                 bookmark="i",
-                description="Network interfaces"
+                description="Network interfaces",
             ),
             LayoutZone(
                 name="CONNECTIONS",
                 zone_type="watch",
-                x=0, y=13, width=50, height=15,
+                x=0,
+                y=13,
+                width=50,
+                height=15,
                 command="ss -tuln 2>/dev/null | head -14 || netstat -tuln | head -14",
                 interval=5,
                 bookmark="c",
-                description="Active connections"
+                description="Active connections",
             ),
             LayoutZone(
                 name="ROUTES",
                 zone_type="watch",
-                x=55, y=0, width=55, height=10,
+                x=55,
+                y=0,
+                width=55,
+                height=10,
                 command="ip route 2>/dev/null || netstat -rn | head -10",
                 interval=30,
                 bookmark="r",
-                description="Routing table"
+                description="Routing table",
             ),
             LayoutZone(
                 name="DNS",
                 zone_type="watch",
-                x=55, y=11, width=55, height=8,
+                x=55,
+                y=11,
+                width=55,
+                height=8,
                 command="cat /etc/resolv.conf | grep -v '^#'",
                 interval=60,
                 bookmark="d",
-                description="DNS configuration"
+                description="DNS configuration",
             ),
             LayoutZone(
                 name="TERMINAL",
                 zone_type="pty",
-                x=55, y=20, width=55, height=10,
+                x=55,
+                y=20,
+                width=55,
+                height=10,
                 bookmark="t",
-                description="Network diagnostics terminal"
+                description="Network diagnostics terminal",
             ),
         ],
     ),
@@ -689,44 +785,59 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="GIT",
                 zone_type="watch",
-                x=0, y=0, width=45, height=10,
+                x=0,
+                y=0,
+                width=45,
+                height=10,
                 command="git status --short 2>/dev/null || echo 'Not a git repo'",
                 interval=5,
                 bookmark="g",
-                description="Git status"
+                description="Git status",
             ),
             LayoutZone(
                 name="TESTS",
                 zone_type="watch",
-                x=0, y=11, width=45, height=12,
+                x=0,
+                y=11,
+                width=45,
+                height=12,
                 command="python -m pytest --co -q 2>/dev/null | head -10 || echo 'No pytest'",
                 interval=30,
                 bookmark="t",
-                description="Test discovery"
+                description="Test discovery",
             ),
             LayoutZone(
                 name="VENV",
                 zone_type="watch",
-                x=0, y=24, width=45, height=6,
-                command="echo \"Python: $(python --version 2>&1)\"; echo \"Venv: ${VIRTUAL_ENV:-none}\"",
+                x=0,
+                y=24,
+                width=45,
+                height=6,
+                command='echo "Python: $(python --version 2>&1)"; echo "Venv: ${VIRTUAL_ENV:-none}"',
                 interval=60,
                 bookmark="v",
-                description="Python environment"
+                description="Python environment",
             ),
             LayoutZone(
                 name="REPL",
                 zone_type="pty",
-                x=50, y=0, width=60, height=15,
+                x=50,
+                y=0,
+                width=60,
+                height=15,
                 shell="python3",
                 bookmark="p",
-                description="Python REPL"
+                description="Python REPL",
             ),
             LayoutZone(
                 name="TERMINAL",
                 zone_type="pty",
-                x=50, y=16, width=60, height=15,
+                x=50,
+                y=16,
+                width=60,
+                height=15,
                 bookmark="e",
-                description="Editor/shell terminal"
+                description="Editor/shell terminal",
             ),
         ],
     ),
@@ -737,18 +848,24 @@ DEFAULT_LAYOUTS = {
             LayoutZone(
                 name="STATUS",
                 zone_type="watch",
-                x=0, y=0, width=40, height=10,
+                x=0,
+                y=0,
+                width=40,
+                height=10,
                 command="echo '=== System ===' && uptime && echo && free -h | head -2",
                 interval=10,
                 bookmark="s",
-                description="Quick system status"
+                description="Quick system status",
             ),
             LayoutZone(
                 name="TERMINAL",
                 zone_type="pty",
-                x=45, y=0, width=70, height=25,
+                x=45,
+                y=0,
+                width=70,
+                height=25,
                 bookmark="t",
-                description="Main terminal"
+                description="Main terminal",
             ),
         ],
     ),


### PR DESCRIPTION
## Summary
- Use `TYPE_CHECKING` pattern to properly type `apply_layout()` handler parameters
- Replace `Any | None` with `"PTYHandler | None"`, `"FIFOHandler | None"`, `"SocketHandler | None"`

## Why TYPE_CHECKING?
The handlers are defined in `zones.py` which already imports from `layouts.py` (potential circular import). Using `TYPE_CHECKING` allows mypy to validate the types without creating a runtime circular dependency.

## Test plan
- [x] All 73 layout tests pass
- [x] mypy no longer reports `Any` type errors for these parameters

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)