### PR TITLE
feat: Add sequential bookmark cycling with [ and ] keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,8 @@ Quick navigation using vim-style marks. 36 slots available (a-z, 0-9).
 |-----|--------|
 | `m` + key | Set bookmark at cursor position |
 | `'` + key | Jump to bookmark |
+| `]` | Cycle to next bookmark (spatial order) |
+| `[` | Cycle to previous bookmark |
 
 **Commands:**
 | Command | Description |
@@ -495,6 +497,8 @@ zones:
 | `:` or `/`      | Enter command mode      |
 | `m` + key       | Set bookmark (a-z, 0-9) |
 | `'` + key       | Jump to bookmark        |
+| `]`             | Next bookmark (spatial) |
+| `[`             | Previous bookmark       |
 | `Esc`           | Exit current mode       |
 | `g` / `G`       | Toggle major/minor grid |
 | `0`             | Toggle origin marker    |


### PR DESCRIPTION
## Summary

Fixes #91 - Sequential bookmark cycling with Space/Tab/[] keys

Adds spatial navigation through bookmarks using vim-style bracket keys:

| Key | Action |
|-----|--------|
| `]` | Jump to next bookmark (spatial order) |
| `[` | Jump to previous bookmark |

## Features

- **Spatial ordering**: Y-then-X (top-to-bottom, left-to-right) - like reading a page
- **Silent wrap**: Cycles from last → first and first → last
- **Stateless**: Finds nearest bookmark on each press (no index tracking)
- **Status message**: `[3/11] 'f' (0,0)` shows position, key, and coordinates
- **Empty state**: "No bookmarks - press m to set"

## Implementation

**BookmarkManager** (4 new methods):
- `_sorted_spatial()` - helper for Y-then-X sorting
- `get_next_spatial(x, y)` - find next bookmark after position
- `get_prev_spatial(x, y)` - find previous bookmark before position
- `get_spatial_index(key)` - get 0-based index in spatial order

**NAV mode**: `[` and `]` character handlers (follows existing `n`/`N` pattern)

## Test plan

- [x] 14 new tests (8 unit + 6 integration)
- [x] All 727 tests pass
- [x] Manual testing: cycling through bookmarks in spatial order

## Usage

```
# Set some bookmarks
m a  (at 0,0)
m b  (at 50,0)
m c  (at 0,50)

# Cycle through them
]    → jumps to 'b' (50,0), shows "[2/3] 'b' (50,0)"
]    → jumps to 'c' (0,50), shows "[3/3] 'c' (0,50)"
]    → wraps to 'a' (0,0), shows "[1/3] 'a' (0,0)"
[    → wraps to 'c' (0,50), shows "[3/3] 'c' (0,50)"
```

🤖 Generated with [Claude Code](https://claude.ai/code)